### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -1,4 +1,6 @@
 name: Backend
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/sergot/tibiacores/security/code-scanning/5](https://github.com/sergot/tibiacores/security/code-scanning/5)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's steps:
- `contents: read` is sufficient for most steps, such as checking out the repository and running tests.
- Additional permissions may be required for the `codecov/codecov-action@v3` step, depending on its functionality. However, the provided background information suggests starting with `contents: read`.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or specifically to the `build` job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
