### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -1,4 +1,6 @@
 name: Frontend
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/sergot/tibiacores/security/code-scanning/4](https://github.com/sergot/tibiacores/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the workflow level (root) to explicitly define the least privileges required. Since the workflow only needs to read the repository contents (e.g., to check out the code and install dependencies), we will set `contents: read`. This ensures that the workflow does not have unnecessary write permissions.

The `permissions` block will be added after the `name` field at the top of the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
